### PR TITLE
Add missing step for running the app on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Assuming you have all the requirements installed, you can setup and run the proj
   - `keytool -genkey -v -keystore debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000`
   - `cd ../..` to come back to the root folder
 - `yarn start` to start the metro bundler, in a dedicated terminal
-- `react-native run-android` to run the Android application (remember to start a simulator or connect an Android phone)
+- `yarn react-native run-android` to run the Android application (remember to start a simulator or connect an Android phone)
 
 ### iOS
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Assuming you have all the requirements installed, you can setup and run the proj
 - `pod install` to install pod dependencies
 - `cd ..` to come back to the root folder
 - `yarn start` to start the metro bundler, in a dedicated terminal
-- `react-native run-ios` to run the iOS application (remember to start a simulator or connect an iPhone phone)
+- `yarn react-native run-ios` to run the iOS application (remember to start a simulator or connect an iPhone phone)
 
 ## Useful documentation
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Assuming you have all the requirements installed, you can setup and run the proj
   - `cd android/app`
   - `keytool -genkey -v -keystore debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000`
   - `cd ../..` to come back to the root folder
+- `yarn start` to start the metro bundler, in a dedicated terminal
 - `react-native run-android` to run the Android application (remember to start a simulator or connect an Android phone)
 
 ### iOS


### PR DESCRIPTION
Even though it is a known step for starting React Native projects, the step for starting Metro bundler should be present in Android section as well (it is already in iOS section).