### PR TITLE
fix: typo in Flipper doc

### DIFF
--- a/documentation/docs/3_Guides/3_6_UsingFlipper.md
+++ b/documentation/docs/3_Guides/3_6_UsingFlipper.md
@@ -4,7 +4,7 @@ title: Using Flipper 🐛
 ---
 
 Flipper is a debugger for React native and, with a plugin, for redux too.
-All you have to do is download [Flipper](https://fbflipper.com/). Afterinstalling it, in Flipper desktop client do:
+All you have to do is download [Flipper](https://fbflipper.com/). After installing it, in Flipper desktop client do:
 
 ```
 Manage Plugins > Install Plugins > search "redux-debugger" > Install


### PR DESCRIPTION
My apologies if you think this PR is inappropriate. 

I see the missing space in the Flipper doc and I could not help myself.