### PR TITLE
Update updated info about code signing in docs

### DIFF
--- a/documentation/docs/3_Guides/BetaBuild.md
+++ b/documentation/docs/3_Guides/BetaBuild.md
@@ -58,17 +58,17 @@ Open your Xcode project and modify some information:
 
 - [ ] In the `General` tab, `Identity` section, change the `Bundle Identifier` to your identifier (useful for Fastlane)
 - [ ] In the `Signing & Capabilities` tab, `Signing` section, disable `Automatically manage signing`
-- [ ] In the `Build Settings` tab, set view filter on top to `All` and `Combined`, then go to the `Signing` section and into `Code Signing Identity`, set `Don't Code Sign` for the `debug` line (including `Any iOS SDK` also) and set `iOS Distribution` for the `release` line (including `Any iOS SDK` also).
+- [ ] In the `Build Settings` tab, set view filter on top to `All` and `Combined`, then go to the `Signing` section and into `Code Signing Identity`, set `Apple Development` for the `debug` line (including `Any iOS SDK` also) and set `Apple Distribution` for the `release` line (including `Any iOS SDK` also).
 
 
 Like this:
 
 | Code Signing Identity  | < Multiple values > |
 | ------------- | ------------- |
-| Debug  | Don't Code Sign  |
-| Any iOS SDK  | Don't Code Sign  |
-| Release  | iOS Distribution  |
-| Any iOS SDK  | iOS Distribution  |
+| Debug  | Apple Development  |
+| Any iOS SDK  | Apple Development  |
+| Release  | Apple Distribution  |
+| Any iOS SDK  | Apple Distribution  |
 
 
 ### Setting up


### PR DESCRIPTION
Selecting `Don't Code Sign` is no longer possible. This PR updates the docs to current values as discussed in #200