### PR TITLE
Update post-init.script.js to solve DEP0147

### DIFF
--- a/post-init.script.js
+++ b/post-init.script.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-const { rmdir } = require('fs').promises;
+const { rm } = require('fs').promises;
 const { applyPlugins } = require('./template/plugins');
 
 applyPlugins().then(async () => {
-  await rmdir('./plugins', { recursive: true });
+  await rm('./plugins', { recursive: true });
 });


### PR DESCRIPTION
As in Node.js deprecations:
```
Type: Runtime

In future versions of Node.js, recursive option will be ignored for 
  fs.rmdir, fs.rmdirSync, and fs.promises.rmdir.

Use 
  fs.rm(path, { recursive: true, force: true }), 
  fs.rmSync(path, { recursive: true, force: true }) or 
  fs.promises.rm(path, { recursive: true, force: true })
instead.
```