### PR TITLE
fix: fixed reanimated 2.3.x babel configuration

### DIFF
--- a/template/babel.config.js
+++ b/template/babel.config.js
@@ -1,17 +1,19 @@
 const presets = ['module:metro-react-native-babel-preset']
 const plugins = []
 
-plugins.push([
-  'module-resolver',
-  {
-    root: ['./src'],
-    extensions: ['.js', '.json'],
-    alias: {
-      '@': './src',
+plugins.push(
+  [
+    'module-resolver',
+    {
+      root: ['./src'],
+      extensions: ['.js', '.json'],
+      alias: {
+        '@': './src',
+      },
     },
-  },
+  ],
   'react-native-reanimated/plugin',
-])
+)
 
 module.exports = {
   presets,


### PR DESCRIPTION
The `react-native-reanimated` babel plugin wasn't added correctly in the upgrade to `2.3.x`, causing reanimated to give an error about the babel plugin missing when using reanimated.