### PR TITLE
Added two cases for full margin and padding

### DIFF
--- a/template/src/Theme/Gutters.js
+++ b/template/src/Theme/Gutters.js
@@ -24,6 +24,9 @@ export default function ({ MetricsSizes }) {
       (acc, [key, value]) => ({
         ...acc,
         /* Margins */
+        [`${key}Margin`]: {
+          margin: value,
+        },
         [`${key}BMargin`]: {
           marginBottom: value,
         },
@@ -43,6 +46,9 @@ export default function ({ MetricsSizes }) {
           marginHorizontal: value,
         },
         /* Paddings */
+        [`${key}Padding`]: {
+          padding: value,
+        },
         [`${key}BPadding`]: {
           paddingBottom: value,
         },


### PR DESCRIPTION
Remove the repeated code when it need to have space for full cases, for example:

```js
<View style={[Gutters.smallTPadding, Gutters.smallRPadding, Gutters.smallLPadding, Gutters.smallBPadding]} />
```

to 
```js
<View style={Gutters.smallPadding} />
```